### PR TITLE
No help@kbase

### DIFF
--- a/SLA_and_POC.md
+++ b/SLA_and_POC.md
@@ -2,7 +2,7 @@
 
 Our normal operating hours are 8am to 7pm Eastern time (7am-6pm Central, 6am-5pm Pacific), Monday through Friday (except holidays).  During these hours, the POC will respond to (not necessarily resolve) production issues within 2 hours.  Outside of these hours, the POC will respond as soon as possible the next business day.  For catastrophic issues that occur outside our normal SLA, the POC will respond as soon as possible.  (Catastrophic issues are those which cause most or all of KBase to be completely unusable with no possible workaround.  Examples include a core service such as workspace or Shock going down.)  Production issues will be routed by the help desk coordinator, internal developers, and the monitoring center to the pager email address.
 
-Issues in non-production environments can be reported to help@kbase.us.  The helpdesk coordinator will route a Jira ticket to the devops component.  These issues will be routed to the most appropriate resource by the POC within one business day.
+Issues in non-production environments can be reported in JIRA (or Slack?). The helpdesk coordinator will route a Jira ticket to the devops component.  These issues will be routed to the most appropriate resource by the POC within one business day.
 
 The POC rotation will be managed in pagerduty. 
 


### PR DESCRIPTION
(There isn't a way to make line-by-line comments on a file in GitHub, only on a PR, so I had to edit this file rather than commenting on it, which is what I wanted to do.)

"Issues in non-production environments can be reported to help@kbase.us" --> NO.
But I'm not sure what the right thing is here--create a ticket in JIRA, ask on Slack (what channel?)? I think maybe this document was created before we started using Slack.

And the Help Desk isn't responsible for assigning internally-created tickets, just external ones.

Also, what is "pagerduty"?